### PR TITLE
Add test for custom subresource instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,16 +8,25 @@
 module.exports.register = function (Handlebars, subresource) {
     subresource = subresource || require("subresource");
 
-    Handlebars.registerHelper("sri", function (filePath, property) {
+    // Varidac function
+    Handlebars.registerHelper("sri", function (filePath) {
         var resource = subresource(filePath);
 
-        // Default to integrity attribute
-        if (typeof property !== "string") {
-            property = "integrity";
+        // Default to integrity.
+        // Handlebars will attach an object as the last argument - ignore it!
+        if (arguments.length <= 2) {
+            return resource.integrity;
         }
 
-        // Static property
-        return resource[property];
+        // Grab an array of arguments, after filePath
+        var properties = [].slice.call(arguments, 1);
+        properties.pop(); // Ignore handlebars' argument
+
+        // Dig down through resource properties
+        // e.g. return resource[arg1][arg2][arg3][arg4];
+        return properties.reduce(function (child, property) {
+            return child[property];
+        }, resource);
     });
 
     return Handlebars;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars-helper-sri",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Sub-resource integrity in Handlebars",
   "author": {
     "name": "Neftaly Hernandez",

--- a/test/custom-instance.js
+++ b/test/custom-instance.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var assert = require("assert"),
+    fs = require("fs"),
+    handlebars = require("handlebars"),
+
+    filePath = "./test/jquery-1.10.2.min.js.testdata",
+    customSubresource;
+
+customSubresource = function () {
+    return {
+        integrity: "hello world"
+    };
+};
+
+// Attach custom handler
+handlebars = require("../index.js").register(handlebars, customSubresource);
+
+it("Custom subresource instance", function () {
+    var expect = "hello world";
+    var result = handlebars.compile("{{sri 123}}")();
+
+    assert.equal(expect, result);
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,22 +1,26 @@
 "use strict";
 
 var assert = require("assert"),
-    handlebars = require("handlebars"),
     fs = require("fs"),
+    handlebars = require("handlebars"),
 
-//    testString = "",
     filePath = "./test/jquery-1.10.2.min.js.testdata";
 
+// Attach handler
 handlebars = require("../index.js").register(handlebars);
 
-it("Default", function () {
-    var expect = "<script src='jquery.js' integrity='sha256-C6CB9UYIS9UJeqinPHWTHVqh/E1uhG5Twh+Y5qFQmYg='></script>";
-    var result = handlebars.compile("<script src='jquery.js' integrity='{{sri filePath}}'></script>")({ filePath: filePath });
-    assert.equal(expect, result);
-});
+describe("Standard subresource instance", function () {
 
-it.skip("Custom subresource instance", function () {
-    var expect = true;
-    var result = false;
-    assert.equal(expect, result);
+    it("Default", function () {
+        var expect = "<script src='jquery.js' integrity='sha256-C6CB9UYIS9UJeqinPHWTHVqh/E1uhG5Twh+Y5qFQmYg='></script>";
+        var result = handlebars.compile("<script src='jquery.js' integrity='{{sri filePath}}'></script>")({ filePath: filePath });
+        assert.equal(expect, result);
+    });
+
+    it("Property", function () {
+        var expect = "C6CB9UYIS9UJeqinPHWTHVqh/E1uhG5Twh+Y5qFQmYg=";
+        var result = handlebars.compile("{{sri filePath 'hashes' 'sha256'}}")({ filePath: filePath });
+        assert.equal(expect, result);
+    });
+
 });


### PR DESCRIPTION
**Potential Node bug**

This currently fails -- probably due to the caching strategy used by `require`. 
The helper attachment seems to persist between scripts.

Setting up a shell script to run each test in a separate instance of mocha appears to be a viable workaround.