### PR TITLE
Add test for custom subresource instance

### DIFF
--- a/test/custom-instance.js
+++ b/test/custom-instance.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var assert = require("assert"),
+    fs = require("fs"),
+    handlebars = require("handlebars"),
+
+    filePath = "./test/jquery-1.10.2.min.js.testdata",
+    customSubresource;
+
+customSubresource = function () {
+    return {
+        integrity: "hello world"
+    };
+};
+
+// Attach custom handler
+handlebars = require("../index.js").register(handlebars, customSubresource);
+
+it("Custom subresource instance", function () {
+    var expect = "hello world";
+    var result = handlebars.compile("{{sri 123}}")();
+
+    assert.equal(expect, result);
+});


### PR DESCRIPTION
**Potential Node bug**

This currently fails -- probably due to the caching strategy used by `require`. 
The helper attachment seems to persist between scripts.

Setting up a shell script to run each test in a separate instance of mocha appears to be a viable workaround.